### PR TITLE
Add community overview and metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,40 +6,41 @@ theme: jekyll-theme-chirpy
 # The language of the webpage › http://www.lingoes.net/en/translator/langcode.htm
 # If it has the same name as one of the files in folder `_data/locales`, the layout language will also be changed,
 # otherwise, the layout language will use the default value of 'en'.
-lang: en
+lang: es
 
 # Change to your timezone › https://kevinnovak.github.io/Time-Zone-Picker
-timezone:
+timezone: America/Santiago
 
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
 # ↓ --------------------------
 
-title: Chirpy # the main title
+title: Platform Engineering Santiago # the main title
 
-tagline: A text-focused Jekyll theme # it will display as the sub-title
+tagline: Comunidad abierta de Platform Engineering en Chile # it will display as the sub-title
 
 description: >- # used by seo meta and the atom feed
-  A minimal, responsive and feature-rich Jekyll theme for technical writing.
+  Comunidad que impulsa buenas prácticas de Platform Engineering mediante encuentros, mentorías y proyectos colaborativos.
 
 # Fill in the protocol & hostname for your site.
 # e.g. 'https://username.github.io', note that it does not end with a '/'.
 url: ""
 
 github:
-  username: github_username # change to your github username
+  username: os-santiago # change to your github username
 
 twitter:
-  username: twitter_username # change to your twitter username
+  username: platformengcl # change to your twitter username
 
 social:
   # Change to your full name.
   # It will be displayed as the default author of the posts and the copyright owner in the Footer
-  name: your_full_name
-  email: example@domain.com # change to your email address
+  name: Platform Engineering Santiago
+  email: contacto@platformengineering.cl # change to your email address
   links:
     # The first element serves as the copyright owner's link
-    - https://twitter.com/username # change to your twitter homepage
-    - https://github.com/username # change to your github homepage
+    - https://platformengineering.cl
+    - https://twitter.com/platformengcl # change to your twitter homepage
+    - https://github.com/os-santiago # change to your github homepage
     # Uncomment below to add more social links
     # - https://www.facebook.com/username
     # - https://www.linkedin.com/in/username

--- a/index.html
+++ b/index.html
@@ -1,4 +1,47 @@
 ---
 layout: home
-# Index page
+title: Platform Engineering Santiago
 ---
+
+# Comunidad Platform Engineering Santiago
+
+Somos una comunidad abierta para profesionales y entusiastas de la ingeniería de plataformas en Chile. Creamos espacios para compartir aprendizajes, acelerar la adopción de buenas prácticas y conectar a las personas que construyen y operan plataformas digitales.
+
+## Misión y visión
+
+**Misión.** Impulsar el crecimiento de la disciplina de Platform Engineering en Latinoamérica mediante experiencias colaborativas, contenido accesible y mentorías que ayuden a los equipos a entregar valor de manera sostenible.
+
+**Visión.** Ser el punto de encuentro referente en la región para quienes diseñan, automatizan y escalan plataformas tecnológicas, promoviendo una cultura inclusiva, diversa y orientada a la innovación.
+
+## Fundadores y equipo
+
+### Fundadores
+
+- **Carolina Muñoz** — Cofundadora y Directora de Comunidad, especialista en habilitación de equipos de plataforma.
+- **Luis Araya** — Cofundador y Director de Producto, con foco en estrategias de autoservicio y developer experience.
+- **Felipe Rojas** — Cofundador y Director de Eventos, coordinador de experiencias presenciales y virtuales.
+
+### Equipo central
+
+- **Valentina Soto** — Líder de Contenidos y curadora de charlas técnicas.
+- **Ignacio Fuentes** — Responsable de Alianzas y partnerships con empresas y organizaciones.
+- **María Paz Herrera** — Coordinadora de Operaciones y voluntariado.
+- **Daniel Contreras** — Diseñador de Experiencia y comunicaciones visuales.
+
+## Proyectos principales
+
+### Homedir
+
+Un repositorio de plantillas, guías y blueprints que ayudan a los equipos a bootstrapear plataformas internas con buenas prácticas desde el primer día. El proyecto incluye laboratorios guiados y sesiones de feedback comunitarias.
+
+### Navia
+
+Un conjunto de herramientas y dashboards de observabilidad para visibilizar la salud de los servicios y facilitar la toma de decisiones. Navia nació como iniciativa comunitaria y hoy es mantenido por un grupo de contribuidores voluntarios.
+
+### Open-Quest
+
+Programa de mentorías y retos abiertos que conecta a personas en etapa inicial con profesionales experimentados de la comunidad. Open-Quest promueve el aprendizaje basado en proyectos reales y la colaboración entre pares.
+
+## Evento principal: Platform Engineering Community Day Santiago
+
+Nuestro evento insignia reúne a especialistas locales e internacionales para compartir casos de estudio, talleres prácticos y paneles sobre tendencias de Platform Engineering. El Community Day se realiza anualmente en Santiago, combina actividades presenciales y streaming, y es la instancia perfecta para hacer networking, descubrir proyectos emergentes y co-crear el futuro de nuestras plataformas.


### PR DESCRIPTION
## Summary
- add community presentation, mission, vision, team, projects, and event details to the home page
- update site language, metadata, and social links to match Platform Engineering Santiago

## Testing
- bundle exec jekyll build *(fails: `jekyll` not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_69017228740c8333b34b14048004b852