### PR TITLE
Fix homepage layout to display custom content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: page
 title: Open Source Santiago — Comunidad, Tecnología y Propósito
 ---
 


### PR DESCRIPTION
## Summary
- switch the homepage to use the `page` layout so the custom markdown renders instead of the post list

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_69017f9e22dc833382131935af2a4dd6