### PR TITLE
Clarify support focus for external initiatives

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: Open Source Santiago — Comunidad, Tecnología y Propósito
 **Open Source Santiago** es una comunidad iniciada por organizadores en Chile, pero pensada desde su origen como un espacio **abierto al mundo**.
 Nuestro propósito es construir un punto de encuentro para personas de distintas culturas, lenguajes y trayectorias que ven en el código abierto una herramienta para generar conocimiento, colaboración y transformación social.
 
-Más allá de adherir a una fundación específica, apoyamos y colaboramos con grandes iniciativas globales como **Linux Foundation**, **CNCF**, **Apache**, **Eclipse**, entre otras, junto a frameworks y herramientas independientes desarrolladas por personas apasionadas, dentro y fuera de nuestra comunidad.
+Más allá de adherir a una fundación específica, apoyamos a quienes desean aprender de grandes iniciativas globales como **Linux Foundation**, **CNCF**, **Apache**, **Eclipse**, entre otras, así como de frameworks y herramientas independientes desarrolladas por personas apasionadas dentro y fuera de nuestra comunidad. No colaboramos directamente con estas iniciativas; orientamos nuestros esfuerzos a acompañar a las personas que quieren aprender de ellas y de sus tecnologías.
 
 > **Creemos en la tecnología como motor para el desarrollo personal, profesional y comunitario.**
 


### PR DESCRIPTION
## Summary
- clarify that the community acompanies people who aprenden de iniciativas globales instead of collaborating directly with them
- update wording to reflect focus on supporting learners and tecnologías

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69018606aa7083338ab2f91946eadacf